### PR TITLE
 Store run configurations in files for sharing and reusing

### DIFF
--- a/run_configs/run_common.py
+++ b/run_configs/run_common.py
@@ -1,8 +1,8 @@
 import sys
+from pathlib import Path
 
-# try different ways to import main.py; it's difficult because main.py is in the parent directory
-sys.path.append('.')
-sys.path.append('..')
+# we need to import main.py from the parent directory
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 from main import main, parse_arguments
 
 

--- a/run_configs/run_common.py
+++ b/run_configs/run_common.py
@@ -1,0 +1,15 @@
+import sys
+
+# try different ways to import main.py; it's difficult because main.py is in the parent directory
+sys.path.append('.')
+sys.path.append('..')
+from main import main, parse_arguments
+
+
+def run(args: dict):
+    """Run the pytorch model with the configuration given in args"""
+    # convert the dictionary into commandline args
+    arg_list = []
+    for k, v in args.items():
+        arg_list += [f"--{k}", str(v)]
+    main(parse_arguments(arg_list))

--- a/run_configs/simple_cnn1.py
+++ b/run_configs/simple_cnn1.py
@@ -1,0 +1,20 @@
+from run_common import run
+
+run(dict(
+    data_dir='../huawei_data/transformed',
+    test_split=0.2,
+    data_subset=0.01,
+    workers=4,
+    save_dir='',
+    epochs=10,
+    train_batch_size=256,
+    test_batch_size=256,
+    learning_rate=0.005,
+    loss='MSELoss',
+    model='SimpleCNN',
+    optim='Adam',
+    gpu_num=0,
+    cnn_in_channels=3,
+    cnn_hidden_channels=32,
+    cnn_num_hidden_layers=7,
+))


### PR DESCRIPTION
When trying out different models, we will have different parameter settings. Those can be stored in scripts in `run_configs/`. I added an example config `simple_cnn1.py`.

It should be possible to run the configurations with either

```
python run_configs/simple_cnn1.py
```

or

```
cd run_configs
python simple_cnn1.py
```