### PR TITLE
Custimize VGG loss with commandline arguments

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,6 +70,10 @@ def parse_arguments(raw_args=None):
     parser.add_argument('-ni', '--no_iso', action='store_true', default=False,
                         help='not to use image ISO values as extra conditioning data')
 
+    # VGG loss
+    parser.add_argument('--vgg_feature_layer', type=int, default=11,
+                        help='VGG19 layer number from which to extract features')
+
     args = parser.parse_args(raw_args)
     args.cuda = not args.no_cuda and torch.cuda.is_available()
     args.iso = not args.no_iso

--- a/main.py
+++ b/main.py
@@ -31,11 +31,14 @@ def parse_arguments(raw_args=None):
     parser.add_argument('-nc', '--no_cuda', action='store_true', default=False,
                         help='disables CUDA training')
 
-    parser.add_argument('--manual_seed', type=int, help='manual seed, if not given resorts to random seed.')
+    parser.add_argument('--manual_seed', type=int,
+                        help='manual seed, if not given resorts to random seed.')
 
     parser.add_argument('-sd', '--save_dir', type=str, metavar='PATH', default='',
-                        help='path to save results and checkpoints to (default: ../results/<model>/<current timestamp>)')
+                        help='path to save results and checkpoints to '
+                             '(default: ../results/<model>/<current timestamp>)')
 
+    # training paramters
     parser.add_argument('--epochs', default=100, type=int, metavar='N',
                         help='number of total epochs to run (default: 100)')
     parser.add_argument('--start_epoch', default=0, type=int, metavar='N',
@@ -48,6 +51,8 @@ def parse_arguments(raw_args=None):
 
     parser.add_argument('-lr', '--learning_rate', default=0.005, type=float,
                         metavar='LR', help='initial learning rate (default: 0.005)')
+
+    # model parameters
     parser.add_argument('--loss', type=str, default='MSELoss')
     parser.add_argument('--model', type=str, default='SimpleCNN')
     parser.add_argument('--optim', type=str, default='Adam')
@@ -59,7 +64,8 @@ def parse_arguments(raw_args=None):
                         help='evaluate model on validation set (default: false)')
 
     # gpu/cpu
-    parser.add_argument('--gpu_num', type=int, default=0, metavar='GPU', help='choose GPU to run on.')
+    parser.add_argument('--gpu_num', type=int, default=0, metavar='GPU',
+                        help='choose GPU to run on.')
 
     # CNN
     parser.add_argument('--cnn_in_channels', type=int, default=3)

--- a/optimisation/loss.py
+++ b/optimisation/loss.py
@@ -20,18 +20,20 @@ class VGGLoss(nn.Module):
     the euclidean distance between the feature representations
      of a reconstructed image.
     """
-    def __init__(self, prefactor=0.006, feature_layer=11):
+    feature_layer_default = 11  # VGG19 layer number from which to extract features
+
+    def __init__(self, args=None, prefactor=0.006):
         """
         Args:
             prefactor: prefactor by which to scale the loss.
             Rescaling by a factor of 1 / 12.75 gives VGG losses of a scale that
             is comparable to MSE loss. This is equivalent to multiplying with a
             rescaling factor of ≈ 0.006.
-            feature_layer: VGG19 layer number from which to extract features
         """
         super().__init__()
         vgg = torchvision.models.vgg19(pretrained=True)
         self.criterion = nn.MSELoss()
+        feature_layer = self.feature_layer_default if args is None else args.vgg_feature_layer
         self.feature_extractor = _FeatureExtractor(vgg, feature_layer=feature_layer)
         self.prefactor = prefactor
 


### PR DESCRIPTION
I previously added the commandline argument `--args_to_loss` which makes it possible to pass `args` to the loss function. You have to remember to use the flag `--args_to_loss` when using the flag `--vgg_feature_layer`.

We can't pass `args` to the loss function by default because the pre-defined loss functions in `torch.nn` don't accept it.